### PR TITLE
fix name HwpSummaryInformation

### DIFF
--- a/pyhwp/hwp5/filestructure.py
+++ b/pyhwp/hwp5/filestructure.py
@@ -535,7 +535,7 @@ class Hwp5File(ItemConversionStorage):
             return self.with_version(self.bodytext_class)
         if name == 'PrvText':
             return PreviewText
-        if name == '\005HwpSummaryInformation':
+        if name == '\005HwpSummaryInformation' or or name == 'IHwpSummaryInformation':
             return self.with_version(self.summaryinfo_class)
 
     def with_version(self, f):
@@ -549,7 +549,10 @@ class Hwp5File(ItemConversionStorage):
 
     @cached_property
     def summaryinfo(self):
-        return self['\005HwpSummaryInformation']
+        try:
+            return self['\005HwpSummaryInformation']
+        except:
+            return self['IHwpSummaryInformation']
 
     @cached_property
     def docinfo(self):

--- a/pyhwp/hwp5/filestructure.py
+++ b/pyhwp/hwp5/filestructure.py
@@ -535,7 +535,7 @@ class Hwp5File(ItemConversionStorage):
             return self.with_version(self.bodytext_class)
         if name == 'PrvText':
             return PreviewText
-        if name == '\005HwpSummaryInformation' or or name == 'IHwpSummaryInformation':
+        if name == '\005HwpSummaryInformation' or name == 'IHwpSummaryInformation':
             return self.with_version(self.summaryinfo_class)
 
     def with_version(self, f):

--- a/pyhwp/hwp5/summaryinfo.py
+++ b/pyhwp/hwp5/summaryinfo.py
@@ -51,18 +51,11 @@ HWP_PROPERTIES = RESERVED_PROPERTIES + SUMMARY_INFORMATION_PROPERTIES + (
 class HwpSummaryInfoTextFormatter(object):
 
     def formatTextLines(self, hwpsummaryinfo):
-        yield 'Title: {}'.format(hwpsummaryinfo.title)
-        yield 'Subject: {}'.format(hwpsummaryinfo.subject)
-        yield 'Author: {}'.format(hwpsummaryinfo.author)
-        yield 'Keywords: {}'.format(hwpsummaryinfo.keywords)
-        yield 'Comments: {}'.format(hwpsummaryinfo.comments)
-        yield 'Last saved by: {}'.format(hwpsummaryinfo.lastSavedBy)
-        yield 'Revision Number: {}'.format(hwpsummaryinfo.revisionNumber)
-        yield 'Last Printed at: {}'.format(hwpsummaryinfo.lastPrintedTime)
-        yield 'Created at: {}'.format(hwpsummaryinfo.createdTime)
-        yield 'Last saved at: {}'.format(hwpsummaryinfo.lastSavedTime)
-        yield 'Number of pages: {}'.format(hwpsummaryinfo.numberOfPages)
-        yield 'Date: {}'.format(hwpsummaryinfo.dateString)
-        yield 'Number of paragraphs: {}'.format(
-            hwpsummaryinfo.numberOfParagraphs
-        )
+        result = {"Title":hwpsummaryinfo.title, "Subject":hwpsummaryinfo.subject,
+                  "Author":hwpsummaryinfo.author, "Keywords":hwpsummaryinfo.keywords,
+                  "Comments":hwpsummaryinfo.comments, "Last saved by":hwpsummaryinfo.lastSavedBy,
+                  "Revision Number":hwpsummaryinfo.revisionNumber, "Last Printed at":str(hwpsummaryinfo.lastPrintedTime.datetime),
+                  "Created at":str(hwpsummaryinfo.createdTime.datetime), "Last saved at":str(hwpsummaryinfo.lastSavedTime.datetime),
+                  "Number of pages":hwpsummaryinfo.numberOfPages, "Date":hwpsummaryinfo.dateString,
+                  "Number of paragraphs":hwpsummaryinfo.numberOfParagraphs}
+        yield str(result)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\Users\hy00un\Desktop\hwp\pyhwp\hwp5proc-script.py", line 11, in <module>
    load_entry_point('pyhwp==0.1b10.dev0', 'console_scripts', 'hwp5proc')()
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\proc\__init__.py", line 188, in main
    return main(args)
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\proc\summaryinfo.py", line 46, in main
    for textline in formatter.formatTextLines(hwpfile.summaryinfo):
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\utils.py", line 55, in __get__
    value = self.func(obj)
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\filestructure.py", line 552, in summaryinfo
    return self['\005HwpSummaryInformation']
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\storage\__init__.py", line 53, in __getitem__
    item = self.wrapped[name]
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\storage\__init__.py", line 53, in __getitem__
    item = self.wrapped[name]
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\storage\__init__.py", line 53, in __getitem__
    item = self.wrapped[name]
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\storage\__init__.py", line 53, in __getitem__
    item = self.wrapped[name]
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\storage\ole.py", line 41, in __getitem__
    return self.impl.__getitem__(name)
  File "C:\python27\lib\site-packages\pyhwp-0.1b10.dev0-py2.7.egg\hwp5\plat\olefileio.py", line 127, in __getitem__
    raise KeyError('%s not found' % path)
KeyError: u'\x05HwpSummaryInformation not found'
```
소스 코드를 확인 한 결과 \005HwpSummaryInformation 해당 이름만 비교하여 탐지를 못해서
IHwpSummaryInformation을 추가로 비교하여 해결했습니다.

```
if name == '\005HwpSummaryInformation' or name == 'IHwpSummaryInformation':
            return self.with_version(self.summaryinfo_class)
```
```
@cached_property
    def summaryinfo(self):
        try:
            return self['\005HwpSummaryInformation']
        except:
            return self['IHwpSummaryInformation']
```