### PR TITLE
압축되지 않은 binData는 압축을 풀지않도록 고칩니다

### DIFF
--- a/src/hwp5/compressed.py
+++ b/src/hwp5/compressed.py
@@ -68,4 +68,10 @@ def decompress(stream):
         stream: a file-like readable
         returns a file-like readable
     '''
-    return BytesIO(zlib.decompress(stream.read(), -15))  # without gzip header
+    data=stream.read()
+    try:
+        res=BytesIO(zlib.decompress(data, -15))  # without gzip header
+    except zlib.error:
+        res=BytesIO(data)
+
+    return res


### PR DESCRIPTION
jpg와 같은 고용량 binData들이 compress 되지 않은 hwp 파일들이 많습니다. 그런 파일들이 zlib.error를 띄우지 않도록 임시방편으로 수정합니다.